### PR TITLE
내 정보 보기 기능을 추가 합니다.

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -20,3 +20,7 @@ Content-Type: application/json
   "key": "email@emali.com",
   "password": "pwd"
 }
+
+### 회원 조회
+GET http://localhost:8080/member/1
+Authorization: 1

--- a/src/main/java/com/ms/member/exception/UnAuthorizedException.java
+++ b/src/main/java/com/ms/member/exception/UnAuthorizedException.java
@@ -1,0 +1,10 @@
+package com.ms.member.exception;
+
+/**
+ * 인증 실패 예외.
+ */
+public class UnAuthorizedException extends Exception {
+  public UnAuthorizedException() {
+    super("인증정보가 올바르지 않습니다.");
+  }
+}

--- a/src/main/java/com/ms/member/service/MemberFindUseCase.java
+++ b/src/main/java/com/ms/member/service/MemberFindUseCase.java
@@ -1,0 +1,18 @@
+package com.ms.member.service;
+
+import com.ms.member.entity.Member;
+import com.ms.member.exception.MemberNotFoundException;
+
+/**
+ * 회원 조회 유즈케이스.
+ */
+public interface MemberFindUseCase {
+  /**
+   * 회원 아이디로 조회.
+   *
+   * @param id 회원 아이디
+   * @return 회원 정보
+   * @throws MemberNotFoundException 회원을 찾지 못함
+   */
+  Member findById(Long id) throws MemberNotFoundException;
+}

--- a/src/main/java/com/ms/member/service/impl/MemberFindService.java
+++ b/src/main/java/com/ms/member/service/impl/MemberFindService.java
@@ -1,0 +1,24 @@
+package com.ms.member.service.impl;
+
+import com.ms.member.entity.Member;
+import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.repository.MemberRepository;
+import com.ms.member.service.MemberFindUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 회원 조회 유즈케이스의 기본 구현 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class MemberFindService implements MemberFindUseCase {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public Member findById(Long id) throws MemberNotFoundException {
+    return memberRepository.findById(id)
+        .orElseThrow(MemberNotFoundException::new);
+  }
+}

--- a/src/main/java/com/ms/member/web/MemberController.java
+++ b/src/main/java/com/ms/member/web/MemberController.java
@@ -2,22 +2,28 @@ package com.ms.member.web;
 
 import com.ms.member.exception.DuplicateValueException;
 import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.exception.UnAuthorizedException;
 import com.ms.member.mobileauth.service.ValidateMobileAuthTokenUseCase;
 import com.ms.member.mobileauth.service.command.ValidateMobileAuthTokenCommand;
 import com.ms.member.mobileauth.service.exception.InvalidMobileAuthTokenException;
 import com.ms.member.service.MemberCreateUseCase;
+import com.ms.member.service.MemberFindUseCase;
 import com.ms.member.service.command.MemberLoginCommand;
 import com.ms.member.service.command.MemberPersistCommand;
 import com.ms.member.service.impl.LoginServiceFactory;
 import com.ms.member.web.model.LoginRequest;
 import com.ms.member.web.model.MemberCreateRequest;
+import com.ms.member.web.model.MemberInfoResponse;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +37,7 @@ public class MemberController {
   private final MemberCreateUseCase memberCreateUseCase;
   private final ValidateMobileAuthTokenUseCase validateMobileAuthTokenUseCase;
   private final LoginServiceFactory loginServiceFactory;
+  private final MemberFindUseCase memberFindUseCase;
 
   /**
    * 회원 가입(생성).
@@ -82,6 +89,41 @@ public class MemberController {
       );
     } catch (MemberNotFoundException e) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+  }
+
+  /**
+   * 회원 조회 (내정보 조회).
+   *
+   * @param id    회원 아이디
+   * @param token 로그인 토큰
+   * @return 회원 정보
+   */
+  @GetMapping("/member/{id}")
+  ResponseEntity<?> getMember(@PathVariable Long id,
+                              @RequestHeader("authorization") String token) {
+    try {
+      validateLoginToken(id, token);
+      var member = memberFindUseCase.findById(id);
+      return ResponseEntity.ok(
+          MemberInfoResponse.of()
+              .email(member.getEmail())
+              .id(member.getId())
+              .mobile(member.getMobile())
+              .name(member.getName())
+              .nickName(member.getNickName())
+              .build()
+      );
+    } catch (UnAuthorizedException e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    } catch (MemberNotFoundException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  private void validateLoginToken(Long id, String token) throws UnAuthorizedException {
+    if (!token.equals(String.valueOf(id))) {
+      throw new UnAuthorizedException();
     }
   }
 }

--- a/src/main/java/com/ms/member/web/model/MemberInfoResponse.java
+++ b/src/main/java/com/ms/member/web/model/MemberInfoResponse.java
@@ -1,0 +1,35 @@
+package com.ms.member.web.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * 회원 정보 응답.
+ */
+@Value(staticConstructor = "of")
+public class MemberInfoResponse {
+  long id;
+  String email;
+  String nickName;
+  String name;
+  String mobile;
+
+  /**
+   * 기본 생성자.
+   *
+   * @param id       아이디
+   * @param email    이메일
+   * @param nickName 닉네임
+   * @param name     이름
+   * @param mobile   전화번호
+   */
+  @Builder(builderClassName = "Of", builderMethodName = "of")
+  public MemberInfoResponse(long id, String email, String nickName, String name,
+                            String mobile) {
+    this.id = id;
+    this.email = email;
+    this.nickName = nickName;
+    this.name = name;
+    this.mobile = mobile;
+  }
+}

--- a/src/test/java/com/ms/member/service/impl/MemberFindServiceTest.java
+++ b/src/test/java/com/ms/member/service/impl/MemberFindServiceTest.java
@@ -1,0 +1,50 @@
+package com.ms.member.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.ms.member.entity.Member;
+import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("회원 조회 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class MemberFindServiceTest {
+
+  @Mock
+  MemberRepository memberRepository;
+
+  MemberFindService memberFindService;
+
+  @BeforeEach
+  void setUp() {
+    this.memberFindService = new MemberFindService(memberRepository);
+  }
+
+  @Test
+  @DisplayName("회원을 찾지 못하면 MemberNotFoundException 예외를 반환한다.")
+  void notFound() {
+    given(memberRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> {
+      memberFindService.findById(1L);
+    }).isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("회원을 정상 조회 하면 회원 정보를 반환한다")
+  void success() throws MemberNotFoundException {
+    given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.of().id(1L).build()));
+    var member = memberFindService.findById(1L);
+    assertThat(member.getId()).isEqualTo(1L);
+  }
+}


### PR DESCRIPTION
resolved #4 

- 내 정보를 조회 하려면 로그인 토큰이 필요합니다.
- 로그인토큰의 내용과 조회하는 회원의 아이디가 같아야 합니다.
- 인증 정보가 다르다면 401 를 리턴합니다.
- 회원이 업다면 404 를 리턴합니다.