### PR TITLE
비밀번호 재설정 기능을 추가 합니다.

### DIFF
--- a/http/member.http
+++ b/http/member.http
@@ -24,3 +24,22 @@ Content-Type: application/json
 ### 회원 조회
 GET http://localhost:8080/member/1
 Authorization: 1
+
+### 비밀번호 재설정
+PUT http://localhost:8080/member/010-1234-1234
+Content-Type: application/json
+
+{
+  "mobileAuthToken": "010-1234-1234",
+  "password": "PWD"
+}
+
+### 비밀번호 재설정 후 다시 로그인
+POST http://localhost:8080/member/login
+Content-Type: application/json
+
+{
+  "loginKeyType": "EMAIL",
+  "key": "email@emali.com",
+  "password": "PWD"
+}

--- a/src/main/java/com/ms/member/repository/MemberRepository.java
+++ b/src/main/java/com/ms/member/repository/MemberRepository.java
@@ -43,4 +43,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
    * @return 존재 여부
    */
   boolean existsByMobile(String mobile);
+
+  /**
+   * 전화번호로 회원 조회.
+   *
+   * @param mobile 전화번호
+   * @return 회원 옵셔널
+   */
+  Optional<Member> findByMobile(String mobile);
 }

--- a/src/main/java/com/ms/member/service/ResetPasswordUseCase.java
+++ b/src/main/java/com/ms/member/service/ResetPasswordUseCase.java
@@ -1,0 +1,11 @@
+package com.ms.member.service;
+
+import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.service.command.ResetPasswordCommand;
+
+/**
+ * 비밀번호 재설정 유즈케이스.
+ */
+public interface ResetPasswordUseCase {
+  void reset(ResetPasswordCommand command) throws MemberNotFoundException;
+}

--- a/src/main/java/com/ms/member/service/command/ResetPasswordCommand.java
+++ b/src/main/java/com/ms/member/service/command/ResetPasswordCommand.java
@@ -1,0 +1,30 @@
+package com.ms.member.service.command;
+
+import com.ms.member.util.HashingUtil;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * 비밀번호 재설정 커맨드
+ */
+@Value(staticConstructor = "of")
+public class ResetPasswordCommand {
+  String mobile;
+  String resetPassword;
+
+  /**
+   * 기본 생성자.
+   *
+   * @param mobile        전화번호
+   * @param resetPassword 재설정 할 패스워드
+   */
+  @Builder(builderClassName = "Of", builderMethodName = "of")
+  public ResetPasswordCommand(String mobile, String resetPassword) {
+    this.mobile = mobile;
+    this.resetPassword = resetPassword;
+  }
+
+  public String getResetPassword() {
+    return HashingUtil.hashing(resetPassword);
+  }
+}

--- a/src/main/java/com/ms/member/service/impl/ResetPasswordService.java
+++ b/src/main/java/com/ms/member/service/impl/ResetPasswordService.java
@@ -1,0 +1,27 @@
+package com.ms.member.service.impl;
+
+import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.repository.MemberRepository;
+import com.ms.member.service.ResetPasswordUseCase;
+import com.ms.member.service.command.ResetPasswordCommand;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비밀번호 재설정 유즈케이스의 기본 구현 서비스.
+ */
+@Service
+@AllArgsConstructor
+public class ResetPasswordService implements ResetPasswordUseCase {
+
+  private final MemberRepository repository;
+
+  @Transactional
+  @Override
+  public void reset(ResetPasswordCommand command) throws MemberNotFoundException {
+    var member =
+        repository.findByMobile(command.getMobile()).orElseThrow(MemberNotFoundException::new);
+    member.setPassword(command.getResetPassword());
+  }
+}

--- a/src/main/java/com/ms/member/web/MemberController.java
+++ b/src/main/java/com/ms/member/web/MemberController.java
@@ -8,12 +8,15 @@ import com.ms.member.mobileauth.service.command.ValidateMobileAuthTokenCommand;
 import com.ms.member.mobileauth.service.exception.InvalidMobileAuthTokenException;
 import com.ms.member.service.MemberCreateUseCase;
 import com.ms.member.service.MemberFindUseCase;
+import com.ms.member.service.ResetPasswordUseCase;
 import com.ms.member.service.command.MemberLoginCommand;
 import com.ms.member.service.command.MemberPersistCommand;
+import com.ms.member.service.command.ResetPasswordCommand;
 import com.ms.member.service.impl.LoginServiceFactory;
 import com.ms.member.web.model.LoginRequest;
 import com.ms.member.web.model.MemberCreateRequest;
 import com.ms.member.web.model.MemberInfoResponse;
+import com.ms.member.web.model.PasswordResetRequest;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -38,6 +42,7 @@ public class MemberController {
   private final ValidateMobileAuthTokenUseCase validateMobileAuthTokenUseCase;
   private final LoginServiceFactory loginServiceFactory;
   private final MemberFindUseCase memberFindUseCase;
+  private final ResetPasswordUseCase resetPasswordUseCase;
 
   /**
    * 회원 가입(생성).
@@ -126,4 +131,33 @@ public class MemberController {
       throw new UnAuthorizedException();
     }
   }
+
+  @PutMapping("/member/{mobile}")
+  ResponseEntity<?> resetPassword(@RequestBody @Valid PasswordResetRequest request,
+                                  @PathVariable String mobile) {
+    try {
+      validateMobileAuthTokenForResetPassword(request, mobile);
+      resetPasswordUseCase.reset(ResetPasswordCommand.of()
+          .mobile(mobile)
+          .resetPassword(request.getPassword())
+          .build());
+      return ResponseEntity.ok().build();
+    } catch (UnAuthorizedException e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    } catch (InvalidMobileAuthTokenException e) {
+      return ResponseEntity.unprocessableEntity().body(e.getMessage());
+    } catch (MemberNotFoundException e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  private void validateMobileAuthTokenForResetPassword(PasswordResetRequest request, String mobile)
+      throws UnAuthorizedException, InvalidMobileAuthTokenException {
+    validateMobileAuthTokenUseCase.validate(
+        ValidateMobileAuthTokenCommand.of(request.getMobileAuthToken()));
+    if (!request.getMobileAuthToken().equals(mobile)) {
+      throw new UnAuthorizedException();
+    }
+  }
+
 }

--- a/src/main/java/com/ms/member/web/model/PasswordResetRequest.java
+++ b/src/main/java/com/ms/member/web/model/PasswordResetRequest.java
@@ -1,0 +1,28 @@
+package com.ms.member.web.model;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PasswordResetRequest {
+  @NotEmpty(message = "전화번호 인증 정보가 없습니다.")
+  String mobileAuthToken;
+  @NotEmpty(message = "패스워드가 입력되지 않았습니다.")
+  String password;
+
+  /**
+   * 기본 생성자.
+   *
+   * @param mobileAuthToken 전화번호 인증 토큰
+   * @param password        변경 할 패스워드
+   */
+  @Builder(builderClassName = "Of", builderMethodName = "of")
+  public PasswordResetRequest(String mobileAuthToken, String password) {
+    this.mobileAuthToken = mobileAuthToken;
+    this.password = password;
+  }
+}

--- a/src/test/java/com/ms/member/service/impl/ResetPasswordServiceTest.java
+++ b/src/test/java/com/ms/member/service/impl/ResetPasswordServiceTest.java
@@ -1,0 +1,58 @@
+package com.ms.member.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.ms.member.entity.Member;
+import com.ms.member.exception.MemberNotFoundException;
+import com.ms.member.repository.MemberRepository;
+import com.ms.member.service.command.ResetPasswordCommand;
+import com.ms.member.util.HashingUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("비밀번호 재설정 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class ResetPasswordServiceTest {
+
+  @Mock
+  MemberRepository memberRepository;
+
+  ResetPasswordService resetPasswordService;
+
+  @BeforeEach
+  void setUp() {
+    resetPasswordService = new ResetPasswordService(memberRepository);
+  }
+
+  @DisplayName("회원을 찾지 못하면 MemberNotFoundException 예외를 반환한다")
+  @Test
+  void notFound() {
+    given(memberRepository.findByMobile(anyString())).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> {
+      resetPasswordService.reset(ResetPasswordCommand.of("010-1234-1234", "PWD"));
+    }).isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @DisplayName("정상처리 하면 패스워드가 변경된다")
+  @Test
+  void success() throws MemberNotFoundException {
+    var originalPassword = "pwd";
+    var newPassword = "PWD";
+    var givenMember = Member.of().password(originalPassword).build();
+    given(memberRepository.findByMobile(anyString())).willReturn(Optional.of(givenMember));
+
+    resetPasswordService.reset(ResetPasswordCommand.of("010-1234-1234", newPassword));
+
+    assertThat(givenMember.getPassword()).isEqualTo(HashingUtil.hashing(newPassword));
+  }
+
+}

--- a/src/test/java/com/ms/member/web/MemberControllerTest.java
+++ b/src/test/java/com/ms/member/web/MemberControllerTest.java
@@ -16,11 +16,13 @@ import com.ms.member.mobileauth.service.exception.InvalidMobileAuthTokenExceptio
 import com.ms.member.service.MemberCreateUseCase;
 import com.ms.member.service.MemberFindUseCase;
 import com.ms.member.service.MemberLoginUseCase;
+import com.ms.member.service.ResetPasswordUseCase;
 import com.ms.member.service.domain.LoginKeyType;
 import com.ms.member.service.impl.LoginServiceFactory;
 import com.ms.member.service.model.LoginToken;
 import com.ms.member.web.model.LoginRequest;
 import com.ms.member.web.model.MemberCreateRequest;
+import com.ms.member.web.model.PasswordResetRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,6 +54,9 @@ class MemberControllerTest {
 
   @MockBean
   MemberFindUseCase memberFindUseCase;
+
+  @MockBean
+  ResetPasswordUseCase resetPasswordUseCase;
 
   @Nested
   @DisplayName("회원을 생성 할 때")
@@ -190,6 +195,36 @@ class MemberControllerTest {
 
   }
 
+  @Nested
+  @DisplayName("패스워드를 재설정 할 때")
+  class DescribeResetPassword {
+    PasswordResetRequest givenRequest() {
+      return PasswordResetRequest.of()
+          .mobileAuthToken("010-1234-1234").password("pwd").build();
+    }
+
+    @DisplayName("전화번호 인증 토큰과 전화번호가 일치하지 않으면 401를 리턴한다")
+    @Test
+    void unAuthorized() throws Exception {
+      mockMvc.perform(
+              MockMvcRequestBuilders.put("/member/010-1234-4321")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(givenRequest()))
+          ).andDo(print())
+          .andExpect(status().isUnauthorized());
+    }
+
+    @DisplayName("정상 처리를 하면 200을 응답한다")
+    @Test
+    void success() throws Exception {
+      mockMvc.perform(
+              MockMvcRequestBuilders.put("/member/010-1234-1234")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(givenRequest()))
+          ).andDo(print())
+          .andExpect(status().isOk());
+    }
+  }
 
 }
 


### PR DESCRIPTION
resolved #5 

- 비밀번호를 재설정 하려면 전화번호 인증 토큰이 필요합니다.
- 인증토큰의 내용과 요청 전화번호가 동일 해야 변경이 가능합니다. (다르면 401을 반환합니다)
- 해당 전화번호로 회원이 없으면 404 를 반환합니다.