### PR TITLE
`jar`로 실행하면 RestDoc 문서가 제대로 보이지 않는 문제를 수정합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ asciidoctor {
 
 bootJar {
     dependsOn asciidoctor
-    project.logger.lifecycle("${asciidoctor.outputDir}")
     from("${asciidoctor.outputDir}") {
         into 'static/docs'
     }
+    archiveFileName.set "${rootProject.name}.jar"
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,7 +5,7 @@
 :toc: left
 :toclevels: 3
 :sectlinks:
-:snippets: ../../../build/generated-snippets
+:snippets: ./build/generated-snippets
 
 == 전화번호 인증 요청
 


### PR DESCRIPTION
fixed #19 

RestDoc은 공식문서가 참 부실해요